### PR TITLE
feat: イベント駆動アーキテクチャの基礎を実装 (Phase 1-D)

### DIFF
--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -1,0 +1,73 @@
+/**
+ * WebTaleKit Event Type Definitions
+ *
+ * エンジンが発行するイベントの型定義
+ */
+
+/**
+ * イベントペイロードの型定義
+ */
+export interface EventPayloads {
+  // シナリオ関連イベント
+  'scenario:next': { index: number };
+  'scenario:jump': { target: string };
+  'scenario:end': {};
+
+  // テキスト表示関連イベント
+  'text:display:start': { content: string };
+  'text:display:progress': { current: number; total: number };
+  'text:display:end': { content: string };
+  'text:clear': {};
+
+  // 選択肢関連イベント
+  'choice:show': { choices: Array<{ label: string; id: number }> };
+  'choice:selected': { choice: { label: string; id: number } };
+
+  // リソース関連イベント
+  'resource:loading:start': { path: string; type: string };
+  'resource:loading:progress': { loaded: number; total: number };
+  'resource:loading:complete': { path: string; type: string };
+  'resource:loading:error': { path: string; type: string; error: Error };
+
+  // シーン関連イベント
+  'scene:loaded': { sceneName: string };
+  'scene:unloaded': { sceneName: string };
+  'scene:changed': { from: string; to: string };
+
+  // セーブ/ロード関連イベント
+  'save:start': { slot: string };
+  'save:completed': { slot: string; name: string };
+  'save:error': { slot: string; error: Error };
+  'load:start': { slot: string };
+  'load:completed': { slot: string };
+  'load:error': { slot: string; error: Error };
+
+  // 画像関連イベント
+  'image:show': { key: string; src: string };
+  'image:hide': { key: string };
+  'image:move': { key: string; from: { x: number; y: number }; to: { x: number; y: number } };
+
+  // 音声関連イベント
+  'sound:play': { mode: string; src: string };
+  'sound:stop': { mode: string; src: string };
+  'sound:pause': { mode: string; src: string };
+  'sound:resume': { mode: string; src: string };
+
+  // システム関連イベント
+  'system:ready': {};
+  'system:error': { error: Error };
+  'system:pause': {};
+  'system:resume': {};
+}
+
+/**
+ * イベント名の型
+ */
+export type TaleKitEventName = keyof EventPayloads;
+
+/**
+ * イベントハンドラーの型
+ */
+export type TaleKitEventHandler<T extends TaleKitEventName> = (
+  payload: EventPayloads[T]
+) => void;

--- a/src/utils/eventEmitter.ts
+++ b/src/utils/eventEmitter.ts
@@ -1,0 +1,113 @@
+/**
+ * EventEmitter
+ *
+ * イベント駆動アーキテクチャを実現するための基本クラス
+ */
+
+type EventHandler = (...args: any[]) => void;
+
+export class EventEmitter {
+  private events: Map<string, Set<EventHandler>>;
+
+  constructor() {
+    this.events = new Map();
+  }
+
+  /**
+   * イベントリスナーを登録
+   * @param event イベント名
+   * @param handler イベントハンドラー
+   */
+  on(event: string, handler: EventHandler): void {
+    if (!this.events.has(event)) {
+      this.events.set(event, new Set());
+    }
+    this.events.get(event)!.add(handler);
+  }
+
+  /**
+   * 一度だけ実行されるイベントリスナーを登録
+   * @param event イベント名
+   * @param handler イベントハンドラー
+   */
+  once(event: string, handler: EventHandler): void {
+    const onceHandler: EventHandler = (...args: any[]) => {
+      handler(...args);
+      this.off(event, onceHandler);
+    };
+    this.on(event, onceHandler);
+  }
+
+  /**
+   * イベントリスナーを削除
+   * @param event イベント名
+   * @param handler イベントハンドラー
+   */
+  off(event: string, handler: EventHandler): void {
+    const handlers = this.events.get(event);
+    if (handlers) {
+      handlers.delete(handler);
+      if (handlers.size === 0) {
+        this.events.delete(event);
+      }
+    }
+  }
+
+  /**
+   * 指定したイベントの全リスナーを削除
+   * @param event イベント名
+   */
+  removeAllListeners(event?: string): void {
+    if (event) {
+      this.events.delete(event);
+    } else {
+      this.events.clear();
+    }
+  }
+
+  /**
+   * イベントを発火
+   * @param event イベント名
+   * @param args イベントに渡す引数
+   */
+  emit(event: string, ...args: any[]): void {
+    const handlers = this.events.get(event);
+    if (handlers) {
+      handlers.forEach(handler => {
+        try {
+          handler(...args);
+        } catch (error) {
+          console.error(`Error in event handler for '${event}':`, error);
+        }
+      });
+    }
+  }
+
+  /**
+   * 指定したイベントのリスナー数を取得
+   * @param event イベント名
+   * @returns リスナーの数
+   */
+  listenerCount(event: string): number {
+    const handlers = this.events.get(event);
+    return handlers ? handlers.size : 0;
+  }
+
+  /**
+   * 指定したイベントのリスナー一覧を取得
+   * @param event イベント名
+   * @returns リスナーの配列
+   */
+  listeners(event: string): EventHandler[] {
+    const handlers = this.events.get(event);
+    return handlers ? Array.from(handlers) : [];
+  }
+
+  /**
+   * 登録されている全イベント名を取得
+   * @returns イベント名の配列
+   */
+  eventNames(): string[] {
+    return Array.from(this.events.keys());
+  }
+}


### PR DESCRIPTION
CoreクラスにEventEmitterを統合し、主要なイベントの発行を開始しました。

変更内容:
- EventEmitterクラスを実装 (src/utils/eventEmitter.ts)
- イベント型定義を追加 (src/types/events.d.ts)
- CoreクラスをEventEmitterから継承
- 主要なハンドラーにイベント発行を追加:
  - text:display:start / text:display:end
  - save:start / save:completed
  - load:start / load:completed / load:error

これにより、外部からエンジンの状態を監視し、
カスタムUIやログ機能を実装できるようになりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)