### PR TITLE
feat: カスタムエラークラスを追加 (Phase 1-B)

### DIFF
--- a/src/errors/ParseError.ts
+++ b/src/errors/ParseError.ts
@@ -1,0 +1,45 @@
+/**
+ * ParseError
+ *
+ * シナリオファイルのパース時に発生するエラーを表すカスタムエラークラス
+ */
+export class ParseError extends Error {
+  /**
+   * @param message エラーメッセージ
+   * @param line エラーが発生した行番号
+   * @param column エラーが発生した列番号
+   * @param tag エラーが発生したタグ名
+   * @param originalError 元のエラー（存在する場合）
+   */
+  constructor(
+    message: string,
+    public line: number,
+    public column: number,
+    public tag: string,
+    public originalError?: Error
+  ) {
+    super(message);
+    this.name = 'ParseError';
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ParseError);
+    }
+  }
+
+  /**
+   * エラー情報を文字列として取得
+   * @returns フォーマットされたエラー文字列
+   */
+  toString(): string {
+    return `[ParseError] Line ${this.line}, Column ${this.column}: ${this.message} (Tag: <${this.tag}>)`;
+  }
+
+  /**
+   * ユーザーフレンドリーなエラーメッセージを取得
+   * @returns ユーザー向けのエラーメッセージ
+   */
+  getUserFriendlyMessage(): string {
+    return `シナリオの記述にエラーがあります (${this.line}行目)\nタグ: <${this.tag}>\n詳細: ${this.message}`;
+  }
+}

--- a/src/errors/ResourceError.ts
+++ b/src/errors/ResourceError.ts
@@ -1,0 +1,88 @@
+/**
+ * ResourceError
+ *
+ * リソースファイルの読み込み時に発生するエラーを表すカスタムエラークラス
+ */
+export class ResourceError extends Error {
+  /**
+   * @param message エラーメッセージ
+   * @param resourcePath リソースのパス
+   * @param resourceType リソースのタイプ
+   * @param originalError 元のエラー（存在する場合）
+   */
+  constructor(
+    message: string,
+    public resourcePath: string,
+    public resourceType: 'image' | 'audio' | 'video' | 'template' | 'scenario',
+    public originalError?: Error
+  ) {
+    super(message);
+    this.name = 'ResourceError';
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ResourceError);
+    }
+  }
+
+  /**
+   * エラー情報を文字列として取得
+   * @returns フォーマットされたエラー文字列
+   */
+  toString(): string {
+    return `[ResourceError] Failed to load ${this.resourceType}: ${this.resourcePath}\n${this.message}`;
+  }
+
+  /**
+   * ユーザーフレンドリーなエラーメッセージを取得
+   * @returns ユーザー向けのエラーメッセージ
+   */
+  getUserFriendlyMessage(): string {
+    const typeNames = {
+      image: '画像',
+      audio: '音声',
+      video: '動画',
+      template: 'テンプレート',
+      scenario: 'シナリオ'
+    };
+
+    return `${typeNames[this.resourceType]}の読み込みに失敗しました\nパス: ${this.resourcePath}\n詳細: ${this.message}`;
+  }
+
+  /**
+   * リソースが見つからないエラーを作成
+   * @param resourcePath リソースのパス
+   * @param resourceType リソースのタイプ
+   * @returns ResourceErrorインスタンス
+   */
+  static notFound(
+    resourcePath: string,
+    resourceType: 'image' | 'audio' | 'video' | 'template' | 'scenario'
+  ): ResourceError {
+    return new ResourceError(
+      'Resource not found',
+      resourcePath,
+      resourceType
+    );
+  }
+
+  /**
+   * リソースの読み込みに失敗したエラーを作成
+   * @param resourcePath リソースのパス
+   * @param resourceType リソースのタイプ
+   * @param originalError 元のエラー
+   * @returns ResourceErrorインスタンス
+   */
+  static loadFailed(
+    resourcePath: string,
+    resourceType: 'image' | 'audio' | 'video' | 'template' | 'scenario',
+    originalError?: Error
+  ): ResourceError {
+    return new ResourceError(
+      'Failed to load resource',
+      resourcePath,
+      resourceType,
+      originalError
+    );
+  }
+}

--- a/src/errors/ScenarioError.ts
+++ b/src/errors/ScenarioError.ts
@@ -1,0 +1,110 @@
+/**
+ * ScenarioError
+ *
+ * シナリオ実行時に発生するエラーを表すカスタムエラークラス
+ */
+export class ScenarioError extends Error {
+  /**
+   * @param message エラーメッセージ
+   * @param scenarioName シナリオ名
+   * @param commandType コマンドタイプ（タグ名など）
+   * @param context エラーが発生したコンテキスト情報
+   * @param originalError 元のエラー（存在する場合）
+   */
+  constructor(
+    message: string,
+    public scenarioName: string,
+    public commandType?: string,
+    public context?: Record<string, any>,
+    public originalError?: Error
+  ) {
+    super(message);
+    this.name = 'ScenarioError';
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ScenarioError);
+    }
+  }
+
+  /**
+   * エラー情報を文字列として取得
+   * @returns フォーマットされたエラー文字列
+   */
+  toString(): string {
+    const commandInfo = this.commandType ? ` (Command: ${this.commandType})` : '';
+    const contextInfo = this.context ? `\nContext: ${JSON.stringify(this.context, null, 2)}` : '';
+    return `[ScenarioError] ${this.scenarioName}${commandInfo}: ${this.message}${contextInfo}`;
+  }
+
+  /**
+   * ユーザーフレンドリーなエラーメッセージを取得
+   * @returns ユーザー向けのエラーメッセージ
+   */
+  getUserFriendlyMessage(): string {
+    const commandInfo = this.commandType ? `\nコマンド: ${this.commandType}` : '';
+    return `シナリオの実行中にエラーが発生しました\nシナリオ: ${this.scenarioName}${commandInfo}\n詳細: ${this.message}`;
+  }
+
+  /**
+   * 必須属性が欠けている場合のエラーを作成
+   * @param scenarioName シナリオ名
+   * @param commandType コマンドタイプ
+   * @param attributeName 欠けている属性名
+   * @returns ScenarioErrorインスタンス
+   */
+  static missingAttribute(
+    scenarioName: string,
+    commandType: string,
+    attributeName: string
+  ): ScenarioError {
+    return new ScenarioError(
+      `Required attribute '${attributeName}' is missing`,
+      scenarioName,
+      commandType
+    );
+  }
+
+  /**
+   * 無効な属性値の場合のエラーを作成
+   * @param scenarioName シナリオ名
+   * @param commandType コマンドタイプ
+   * @param attributeName 属性名
+   * @param value 無効な値
+   * @returns ScenarioErrorインスタンス
+   */
+  static invalidAttribute(
+    scenarioName: string,
+    commandType: string,
+    attributeName: string,
+    value: any
+  ): ScenarioError {
+    return new ScenarioError(
+      `Invalid value '${value}' for attribute '${attributeName}'`,
+      scenarioName,
+      commandType,
+      { attributeName, value }
+    );
+  }
+
+  /**
+   * コマンド実行失敗のエラーを作成
+   * @param scenarioName シナリオ名
+   * @param commandType コマンドタイプ
+   * @param originalError 元のエラー
+   * @returns ScenarioErrorインスタンス
+   */
+  static executionFailed(
+    scenarioName: string,
+    commandType: string,
+    originalError?: Error
+  ): ScenarioError {
+    return new ScenarioError(
+      'Command execution failed',
+      scenarioName,
+      commandType,
+      undefined,
+      originalError
+    );
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Custom Error Classes
+ *
+ * WebTaleKitで使用するカスタムエラークラスをエクスポート
+ */
+
+export { ParseError } from './ParseError';
+export { ResourceError } from './ResourceError';
+export { ScenarioError } from './ScenarioError';


### PR DESCRIPTION
ParseError, ResourceError, ScenarioErrorの3つのカスタムエラークラスを実装しました。

- ParseError: シナリオファイルのパース時のエラー
- ResourceError: リソース読み込み時のエラー
- ScenarioError: シナリオ実行時のエラー

各エラークラスには、開発者向けとユーザー向けの2種類のメッセージ機能を実装しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)