### PR TITLE
二作目のサンプルゲーム「cafe story」を作っているときに出た不具合を修正

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -323,7 +323,6 @@ export class Core {
       // scenarioManagerに追加
       this.scenarioManager.setScenario([...noEditScenarioList.before, ...subFalseScenario, ...filteredAfter])
     }
-    this.newpageHandler()
     this.scenarioManager.setIndex(Number(line.index))
   }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -520,14 +520,6 @@ export class Core {
   }
 
   async routeHandler(line) {
-    if (this.bgm.isPlaying) {
-      // BGMを停止する
-      this.soundHandler({
-        mode: 'bgm',
-        src: this.sceneConfig.bgm,
-        stop: true,
-      })
-    }
     this.newpageHandler()
     if (this.sceneFile.cleanUp) {
       // 終了処理を実行する

--- a/src/core/scenarioManager.test.ts
+++ b/src/core/scenarioManager.test.ts
@@ -141,5 +141,7 @@ describe('ScenarioManager next / hasNext guards', () => {
     const indexBefore = sm.getIndex()
     expect(sm.next()).toBeNull()
     expect(sm.getIndex()).toBe(indexBefore)
+    expect(sm.next()).toBeNull()
+    expect(sm.getIndex()).toBe(indexBefore)
   })
 })

--- a/src/core/scenarioManager.test.ts
+++ b/src/core/scenarioManager.test.ts
@@ -114,6 +114,48 @@ describe('ScenarioManager snapshot / restore', () => {
   })
 })
 
+describe('ScenarioManager setScenario cloning', () => {
+  let sm: ScenarioManager
+
+  beforeEach(() => {
+    sm = new ScenarioManager()
+  })
+
+  test('setScenario がディープクローンを行い、元の配列への変更が影響しないこと', () => {
+    const scenario = [{ type: 'text', content: ['original'] }]
+    sm.setScenario(scenario, 'scene1')
+
+    // 元の配列を変更
+    scenario[0].content[0] = 'mutated'
+    scenario.push({ type: 'text', content: ['added'] })
+
+    // ScenarioManager 内部のデータは影響を受けない
+    const stored = sm.getScenario()
+    expect(stored[0].content[0]).toBe('original')
+    expect(stored.length).toBe(1)
+  })
+
+  test('setScenario(undefined) がクラッシュせず空配列として扱われること', () => {
+    expect(() => {
+      sm.setScenario(undefined as any, 'scene1')
+    }).not.toThrow()
+
+    expect(sm.hasNext()).toBe(false)
+    expect(sm.next()).toBeNull()
+    expect(sm.getScenario()).toEqual([])
+  })
+
+  test('setScenario(null) がクラッシュせず空配列として扱われること', () => {
+    expect(() => {
+      sm.setScenario(null as any, 'scene1')
+    }).not.toThrow()
+
+    expect(sm.hasNext()).toBe(false)
+    expect(sm.next()).toBeNull()
+    expect(sm.getScenario()).toEqual([])
+  })
+})
+
 describe('ScenarioManager next / hasNext guards', () => {
   let sm: ScenarioManager
 

--- a/src/core/scenarioManager.test.ts
+++ b/src/core/scenarioManager.test.ts
@@ -113,3 +113,33 @@ describe('ScenarioManager snapshot / restore', () => {
     expect(snap.scenario[0].content[0]).toBe('original')
   })
 })
+
+describe('ScenarioManager next / hasNext guards', () => {
+  let sm: ScenarioManager
+
+  beforeEach(() => {
+    sm = new ScenarioManager()
+  })
+
+  test('scenario が未設定のとき next は null、hasNext は false を返すこと', () => {
+    expect(sm.hasNext()).toBe(false)
+    expect(sm.next()).toBeNull()
+  })
+
+  test('scenario が空配列のとき next は null、hasNext は false を返すこと', () => {
+    sm.setScenario([], 'scene1')
+    expect(sm.hasNext()).toBe(false)
+    expect(sm.next()).toBeNull()
+  })
+
+  test('末尾到達後の next は null を返し index を進めないこと', () => {
+    sm.setScenario([{ type: 'text', content: ['A'] }], 'scene1')
+
+    expect(sm.next()).toEqual({ type: 'text', content: ['A'] })
+    expect(sm.hasNext()).toBe(false)
+
+    const indexBefore = sm.getIndex()
+    expect(sm.next()).toBeNull()
+    expect(sm.getIndex()).toBe(indexBefore)
+  })
+})

--- a/src/core/scenarioManager.ts
+++ b/src/core/scenarioManager.ts
@@ -30,7 +30,7 @@ export class ScenarioManager {
   }
 
   setScenario (scenario: any, sceneName: string=''): void {
-    this.scenarioData = scenario
+    this.scenarioData =  JSON.parse(JSON.stringify(scenario))
     this.progress.currentScene = sceneName
     this.progress.currentIndex = 0
   }

--- a/src/core/scenarioManager.ts
+++ b/src/core/scenarioManager.ts
@@ -55,17 +55,23 @@ export class ScenarioManager {
   }
 
   next(): any {
-   if(this.progress.currentIndex <= (this.scenarioData?.length || 0)) {
-     const nextScenario = this.scenarioData[this.progress.currentIndex] 
-     this.progress.currentIndex += 1
-     return  nextScenario
-   } else {
-    return null
-   }
+    if (!Array.isArray(this.scenarioData)) {
+      return null
+    }
+    if (this.progress.currentIndex >= this.scenarioData.length) {
+      return null
+    }
+
+    const nextScenario = this.scenarioData[this.progress.currentIndex]
+    this.progress.currentIndex += 1
+    return nextScenario
   }
 
   hasNext(): boolean {
-    return this.progress.currentIndex < (this.scenarioData?.length || 0)
+    if (!Array.isArray(this.scenarioData)) {
+      return false
+    }
+    return this.progress.currentIndex < this.scenarioData.length
   }
 
   getIndex(): number {

--- a/src/core/scenarioManager.ts
+++ b/src/core/scenarioManager.ts
@@ -30,7 +30,8 @@ export class ScenarioManager {
   }
 
   setScenario (scenario: any, sceneName: string=''): void {
-    this.scenarioData =  JSON.parse(JSON.stringify(scenario))
+    const normalizedScenario = scenario ?? []
+    this.scenarioData = JSON.parse(JSON.stringify(normalizedScenario))
     this.progress.currentScene = sceneName
     this.progress.currentIndex = 0
   }

--- a/src/core/scenarioManager.ts
+++ b/src/core/scenarioManager.ts
@@ -54,7 +54,7 @@ export class ScenarioManager {
   }
 
   next(): any {
-   if(this.progress.currentIndex <= this.scenarioData.length) {
+   if(this.progress.currentIndex <= (this.scenarioData?.length || 0)) {
      const nextScenario = this.scenarioData[this.progress.currentIndex] 
      this.progress.currentIndex += 1
      return  nextScenario
@@ -64,7 +64,7 @@ export class ScenarioManager {
   }
 
   hasNext(): boolean {
-    return this.progress.currentIndex < this.scenarioData.length
+    return this.progress.currentIndex < (this.scenarioData?.length || 0)
   }
 
   getIndex(): number {

--- a/src/core/scenarioManager.ts
+++ b/src/core/scenarioManager.ts
@@ -38,7 +38,7 @@ export class ScenarioManager {
   addScenario (scenario: any, index: number): void {
     // 区別にsub=trueを追加
     const _scenario =  scenario.map((item: any) => ({ ...item, sub: true }))
-    // この行を消すと動く
+    // この行を消すと動く(原因があまりにも単純でまぬけすぎたので、残しておく)
     // ('call','debug', {scenario, index})
     // index指定がある場合はその値に挿入する
     if(index) {


### PR DESCRIPTION
このプルリクエストは、シナリオデータの代入前にディープクローンを行い、未定義データへの防御的チェックを追加することで、シナリオ処理の安定性向上と意図しない副作用の防止に焦点を当てています。また、軽微なコードの整理と、ルートハンドラから不要なBGM停止ロジックの削除も含まれています。

**シナリオデータ処理の改善:**
* `ScenarioManager.setScenario` においてシナリオデータをディープクローンしてから代入するようにし、元のシナリオオブジェクトへの変更を防止。参照の共有に起因する潜在的なバグを低減します。
* `ScenarioManager.next` および `ScenarioManager.hasNext` に、シナリオデータが存在しない場合のランタイムエラーを防ぐため、`undefined` および `null` に対する防御的チェックを追加。[[1]](diffhunk://#diff-4feb7d5d0905eff9ce0791dd32f13416ca2731d453a76f8ed346cd67a92a2a48L57-R57) [[2]](diffhunk://#diff-4feb7d5d0905eff9ce0791dd32f13416ca2731d453a76f8ed346cd67a92a2a48L67-R67)

**コード整理とロジックの簡略化:**
* `Core` のシナリオ更新ロジック末尾から `this.newpageHandler()` の呼び出しを削除。シナリオ変更時に意図しないページ遷移が発生するのを防ぐためと思われます。
* `Core.routeHandler` から不要なBGM停止ロジックを削除し、ルート処理の簡略化と冗長なサウンド操作の回避を図っています。