### PR TITLE
Fix/overflow chara image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "jest": "^29.7.0",
         "postcss": "^8.4.49",
         "prettier": "^3.2.5",
+        "shx": "^0.3.4",
         "tailwindcss": "^3.4.15",
         "ts-jest": "^29.1.2",
         "ts-loader": "^9.5.1",
@@ -13297,6 +13298,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shelljs/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/shiki": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
@@ -13312,6 +13353,33 @@
         "@shikijs/types": "2.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/shx/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -25784,6 +25852,34 @@
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        }
+      }
+    },
     "shiki": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
@@ -25798,6 +25894,24 @@
         "@shikijs/types": "2.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+          "dev": true
+        }
       }
     },
     "side-channel": {

--- a/src/commands/HideHandler.ts
+++ b/src/commands/HideHandler.ts
@@ -8,6 +8,10 @@ export class HideHandler implements CommandHandler {
     if (!targetImage) {
       throw new Error(`Image not found: ${line.name}`)
     }
+    if (line.transition === 'fade') {
+      // フェードアウト効果で非表示（他の画像とのz-index順を保ったまま対象画像だけをフェードさせる）
+      await drawer.fadeImageOut(line.name, core.displayedImages, line.duration || 1000)
+    }
     if (line.mode === 'cg') {
       core.displayedImages = { ...core.tempImages }
       core.tempImages = {}
@@ -15,13 +19,5 @@ export class HideHandler implements CommandHandler {
       delete core.displayedImages[line.name]
     }
     drawer.show(core.displayedImages)
-    if (line.transition === 'fade') {
-      // フェードアウト効果で非表示
-      await drawer.fadeOut(line.duration || 1000, targetImage.image, {
-        pos: targetImage.pos,
-        size: targetImage.size,
-        look: targetImage.look,
-      })
-    }
   }
 }

--- a/src/commands/ShowHandler.ts
+++ b/src/commands/ShowHandler.ts
@@ -88,14 +88,10 @@ export class ShowHandler implements CommandHandler {
     core.displayedImages[key] = activeImage
 
     if (line.transition === 'fade') {
-      // フェードイン効果で表示
-      await drawer.fadeIn(line.duration || 2000, await core.getImageObject(line), {
-        pos: activeImage.pos,
-        size: activeImage.size,
-        look: line.look,
-        entry: line.entry,
-      })
-      drawer.show(core.displayedImages)
+      // フェードイン効果で表示（他の画像とのz-index順を保ったまま対象画像だけをフェードさせる）
+      // 同じキーに既存表示があった場合は、それを下地にクロスフェードさせ、切り替え中に画面が
+      // 何も表示されない状態（黒画面）になることを防ぐ
+      await drawer.fadeImageIn(key, core.displayedImages, line.duration || 2000, sourceImage)
     } else {
       // 通常の表示処理
       drawer.show(core.displayedImages)

--- a/src/commands/ShowHandler.ts
+++ b/src/commands/ShowHandler.ts
@@ -19,22 +19,37 @@ export class ShowHandler implements CommandHandler {
       center: { x: engineConfig.resolution.width * 0.5, y: baseLine },
       right: { x: engineConfig.resolution.width * 0.75, y: baseLine },
     }
-    line.src = core.expandVariable(line.src) || line.name
+    line.src = core.expandVariable(line.src)
 
     const sourceImage = core.displayedImages[key]
     const activeImage = sourceImage
       ? { ...sourceImage, pos: { ...sourceImage.pos }, size: { ...sourceImage.size } }
       : { image: null, pos: { x: 0, y: 0 }, size: { width: 0, height: 0 }, look: '', entry: '', 'z-index': 0 }
-    // srcが変わっていない場合のみ既存の画像インスタンスを再利用し、それ以外は読み込み直す
-    if (!activeImage.image || activeImage.src !== line.src) {
-      activeImage.image = await core.getImageObject(line)
+    // srcが指定されておらず既存画像がある場合はそのまま再利用し、srcが変わった場合のみ読み込み直す
+    if (!activeImage.image || (line.src && activeImage.src !== line.src)) {
+      activeImage.image = await core.getImageObject({ ...line, src: line.src || activeImage.src })
     }
-    activeImage.src = line.src
+    activeImage.src = line.src ? line.src : activeImage.src
     // 画像の表示位置を設定（座標指定がある場合はそれを優先、ない場合はdisplayImages.posの値を参照して設定）
     activeImage.pos.x = line.x || activeImage.pos.x || 0
     activeImage.pos.y = line.y || activeImage.pos.y || 0
     activeImage.size.width = line.width || activeImage.size.width || activeImage.image.getSize().width
     activeImage.size.height = line.height || activeImage.size.height || activeImage.image.getSize().height
+
+    // charaモード（modeが未指定の場合も含む、bg/cg/cutin/effect以外）でwidth/heightが未指定の場合、
+    // 解像度に収まるようアスペクト比を保って自動縮小する（拡大はしない）
+    const isCharaLikeMode = !['bg', 'cg', 'cutin', 'effect'].includes(line.mode)
+    if (isCharaLikeMode && !line.width && !line.height) {
+      const naturalSize = activeImage.image.getSize()
+      const fitScale = Math.min(
+        engineConfig.resolution.width / naturalSize.width,
+        engineConfig.resolution.height / naturalSize.height,
+        1
+      )
+      activeImage.size.width = naturalSize.width * fitScale
+      activeImage.size.height = naturalSize.height * fitScale
+    }
+
     activeImage.look = line.look || activeImage.look || ''
     activeImage.entry = line.entry || activeImage.entry || ''
     activeImage['z-index'] = line['z-index'] || activeImage['z-index'] || 0

--- a/src/commands/ShowHandler.ts
+++ b/src/commands/ShowHandler.ts
@@ -33,7 +33,7 @@ export class ShowHandler implements CommandHandler {
       }
       activeImage.image = await core.getImageObject({ ...line, src: resolvedSrc })
     }
-    activeImage.src = resolvedSrc || activeImage.src
+    activeImage.src = resolvedSrc
     // 画像の表示位置を設定（座標指定がある場合はそれを優先、ない場合はdisplayImages.posの値を参照して設定）
     activeImage.pos.x = line.x || activeImage.pos.x || 0
     activeImage.pos.y = line.y || activeImage.pos.y || 0

--- a/src/commands/ShowHandler.ts
+++ b/src/commands/ShowHandler.ts
@@ -26,10 +26,14 @@ export class ShowHandler implements CommandHandler {
       ? { ...sourceImage, pos: { ...sourceImage.pos }, size: { ...sourceImage.size } }
       : { image: null, pos: { x: 0, y: 0 }, size: { width: 0, height: 0 }, look: '', entry: '', 'z-index': 0 }
     // srcが指定されておらず既存画像がある場合はそのまま再利用し、srcが変わった場合のみ読み込み直す
+    const resolvedSrc = line.src || activeImage.src
     if (!activeImage.image || (line.src && activeImage.src !== line.src)) {
-      activeImage.image = await core.getImageObject({ ...line, src: line.src || activeImage.src })
+      if (!resolvedSrc) {
+        throw new Error(`[ShowHandler] src is required: no src specified and no existing image found for key "${key}"`)
+      }
+      activeImage.image = await core.getImageObject({ ...line, src: resolvedSrc })
     }
-    activeImage.src = line.src ? line.src : activeImage.src
+    activeImage.src = resolvedSrc || activeImage.src
     // 画像の表示位置を設定（座標指定がある場合はそれを優先、ない場合はdisplayImages.posの値を参照して設定）
     activeImage.pos.x = line.x || activeImage.pos.x || 0
     activeImage.pos.y = line.y || activeImage.pos.y || 0

--- a/src/commands/ShowHandler.ts
+++ b/src/commands/ShowHandler.ts
@@ -68,20 +68,16 @@ export class ShowHandler implements CommandHandler {
 
     if (line.pos) {
       const pos = line.pos.split(':')
+      // top/middle/bottomは、画像の中心をどのY座標に合わせるかを示す基準点
+      // （topを指定すると画像中心が画面上端に来るため、上半身が画面からはみ出す構図になる）
       const baseLines: Record<string, number> = {
-        top: 0 + activeImage.size.height,
+        top: 0,
         middle: engineConfig.resolution.height / 2,
-        bottom: engineConfig.resolution.height - activeImage.size.height,
+        bottom: engineConfig.resolution.height,
       }
       // エイリアスが設定されている場合、画像の中心点を求めて、画像の表示位置を設定する
       activeImage.pos.x = centerPoint[pos[0]].x - activeImage.size.width / 2
-      if (pos[1] === 'middle') {
-        activeImage.pos.y = baseLines[pos[1]] - activeImage.size.height / 2
-      } else if (pos[1]) {
-        activeImage.pos.y = baseLines[pos[1]]
-      } else {
-        activeImage.pos.y = baseLines['middle'] - activeImage.size.height / 2
-      }
+      activeImage.pos.y = baseLines[pos[1] || 'middle'] - activeImage.size.height / 2
     }
 
     if (line.sepia) activeImage.image.setSepia(line.sepia)

--- a/src/core/drawer.test.ts
+++ b/src/core/drawer.test.ts
@@ -1,4 +1,4 @@
-import { sortDisplayedImageEntries } from './drawer'
+import { Drawer, sortDisplayedImageEntries } from './drawer'
 
 describe('sortDisplayedImageEntries', () => {
   test('z-index属性で昇順ソートされること', () => {
@@ -21,5 +21,77 @@ describe('sortDisplayedImageEntries', () => {
 
     const keys = sortDisplayedImageEntries(displayedImages).map(([key]) => key)
     expect(keys).toEqual(['first', 'second', 'third'])
+  })
+})
+
+describe('animateImageAlpha', () => {
+  const originalRaf = global.requestAnimationFrame
+  const originalNow = performance.now
+
+  afterEach(() => {
+    global.requestAnimationFrame = originalRaf
+    performance.now = originalNow
+    jest.restoreAllMocks()
+  })
+
+  const createDrawerForAnimation = () => {
+    const drawer = Object.create(Drawer.prototype) as any
+    const ctx = {
+      canvas: { width: 1280, height: 720 },
+      clearRect: jest.fn(),
+      globalAlpha: 1,
+    } as any
+    const drawCalls: Array<{ id: string; alpha: number }> = []
+    drawer.ctx = ctx
+    drawer.drawCanvas = jest.fn((img: any) => {
+      drawCalls.push({ id: img.id, alpha: ctx.globalAlpha })
+    })
+    return { drawer, drawCalls }
+  }
+
+  const mockAnimationFrames = (times: number[]) => {
+    global.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      const time = times.shift() ?? 1000
+      setImmediate(() => callback(time))
+      return 1
+    })
+    performance.now = jest.fn(() => 0)
+  }
+
+  test('z-index順を維持しつつ対象画像のみalphaが変化すること', async () => {
+    const { drawer, drawCalls } = createDrawerForAnimation()
+    mockAnimationFrames([0, 1000])
+    const displayedImages = {
+      front: { image: { id: 'front' }, size: {}, 'z-index': 3 },
+      target: { image: { id: 'target' }, size: {}, 'z-index': 2 },
+      back: { image: { id: 'back' }, size: {}, 'z-index': 1 },
+    }
+
+    await drawer['animateImageAlpha']('target', displayedImages, 0, 1, 1000)
+
+    expect(drawCalls.slice(0, 3).map((call) => call.id)).toEqual(['back', 'target', 'front'])
+    expect(drawCalls.slice(3, 6).map((call) => call.id)).toEqual(['back', 'target', 'front'])
+    expect(drawCalls.filter((call) => call.id === 'target').map((call) => call.alpha)).toEqual([0, 1])
+    expect(drawCalls.filter((call) => call.id !== 'target').every((call) => call.alpha === 1)).toBe(true)
+  })
+
+  test('previousImageがある場合は対象画像の下地として描画されること', async () => {
+    const { drawer, drawCalls } = createDrawerForAnimation()
+    mockAnimationFrames([0, 1000])
+    const displayedImages = {
+      back: { image: { id: 'back' }, size: {}, 'z-index': 1 },
+      target: { image: { id: 'target' }, size: {}, 'z-index': 2 },
+      front: { image: { id: 'front' }, size: {}, 'z-index': 3 },
+    }
+
+    await drawer['animateImageAlpha']('target', displayedImages, 0, 1, 1000, {
+      image: { id: 'previous' },
+      pos: { x: 0, y: 0 },
+      size: { width: 100, height: 100 },
+    })
+
+    expect(drawCalls.slice(0, 4).map((call) => call.id)).toEqual(['back', 'previous', 'target', 'front'])
+    expect(drawCalls.slice(4, 8).map((call) => call.id)).toEqual(['back', 'previous', 'target', 'front'])
+    expect(drawCalls.filter((call) => call.id === 'previous').every((call) => call.alpha === 1)).toBe(true)
   })
 })

--- a/src/core/drawer.ts
+++ b/src/core/drawer.ts
@@ -354,8 +354,8 @@ export class Drawer {
       ctx = this.ctx
     }
     const canvas = img.draw(reverse).getCanvas()
-    // canvasから画像を取得して、this.ctxに描画
-    ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, pos.x, pos.y, canvas.width, canvas.height) //CanvasRenderingContext2D.drawImage: Passed-in canvas is empty
+    // canvasから画像を取得して、this.ctxに描画（sizeを描画先サイズとして使用し、解像度に合わせて拡縮する）
+    ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, pos.x, pos.y, size.width, size.height)
   }
 
   adjustScale(targetElement: HTMLElement) {

--- a/src/core/drawer.ts
+++ b/src/core/drawer.ts
@@ -322,6 +322,64 @@ export class Drawer {
     this.adjustScale(this.gameScreen)
   }
 
+  // previousImage: 同じキーに既存表示があった場合の差し替え前の画像。フェードイン中はこれを下地として
+  // 常時全不透明で描画し、新しい画像をその上にクロスフェードさせることで、切り替え中に何も表示されない
+  // (黒画面になる)瞬間が生じないようにする。
+  async fadeImageIn(
+    name: string,
+    displayedImages: any,
+    duration: number = 1000,
+    previousImage?: { image: any; pos: any; size: any; look?: any }
+  ): Promise<void> {
+    return this.animateImageAlpha(name, displayedImages, 0, 1, duration, previousImage)
+  }
+
+  async fadeImageOut(name: string, displayedImages: any, duration: number = 1000): Promise<void> {
+    return this.animateImageAlpha(name, displayedImages, 1, 0, duration)
+  }
+
+  // displayedImagesをz-index順に描画しつつ、対象(name)の画像だけ透明度をアニメーションさせる。
+  // fade()の別キャンバス合成と異なり同一キャンバスに描くため、対象画像が常に最前面になってしまう問題を避けられる。
+  private animateImageAlpha(
+    name: string,
+    displayedImages: any,
+    start: number,
+    end: number,
+    duration: number,
+    previousImage?: { image: any; pos: any; size: any; look?: any }
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const startTime = performance.now()
+
+      const animate = (currentTime: number) => {
+        const elapsedTime = currentTime - startTime
+        const progress = Math.min(elapsedTime / duration, 1)
+        const currentAlpha = start + (end - start) * progress
+
+        this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height)
+        for (const [key, imageData] of sortDisplayedImageEntries(displayedImages)) {
+          if (!imageData?.image) continue
+          if (key === name && previousImage?.image) {
+            this.ctx.globalAlpha = 1
+            this.drawCanvas(previousImage.image, previousImage.pos || { x: 0, y: 0 }, previousImage.size, previousImage.look)
+          }
+          const pos = imageData.pos || { x: 0, y: 0 }
+          this.ctx.globalAlpha = key === name ? currentAlpha : 1
+          this.drawCanvas(imageData.image, pos, imageData.size, imageData.look)
+        }
+        this.ctx.globalAlpha = 1
+
+        if (progress < 1) {
+          requestAnimationFrame(animate)
+        } else {
+          resolve()
+        }
+      }
+
+      requestAnimationFrame(animate)
+    })
+  }
+
   moveTo(name: string, displayedImages: any, pos: { x: number; y: number }, durning: number) {
     return new Promise((resolve) => {
       const target = displayedImages[name]

--- a/src/core/drawer.ts
+++ b/src/core/drawer.ts
@@ -413,7 +413,10 @@ export class Drawer {
     }
     const canvas = img.draw(reverse).getCanvas()
     // canvasから画像を取得して、this.ctxに描画（sizeを描画先サイズとして使用し、解像度に合わせて拡縮する）
-    ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, pos.x, pos.y, size.width, size.height)
+    // sizeが未指定の場合はcanvas自体のサイズにフォールバックして後方互換を保つ
+    const destWidth = size?.width ?? canvas.width
+    const destHeight = size?.height ?? canvas.height
+    ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, pos.x, pos.y, destWidth, destHeight)
   }
 
   adjustScale(targetElement: HTMLElement) {


### PR DESCRIPTION
このプルリクエストは、表示エンジンの画像表示・非表示ロジックと視覚効果を改善するものです。特に、より堅牢なフェード遷移の実現と、画像のサイズ調整・配置処理の最適化に重点を置いています。主な変更点として、z-indexの順序を維持しつつ黒い画面のちらつき（フリッカー）を防ぐ新しいフェードイン／フェードアウト・メソッドの導入、キャラクター画像の自動アスペクト比スケーリング、そして一貫性のある画像配置ロジックの採用などが挙げられます。

**画像のフェード遷移に関する改善:**
- `Drawer` クラスに `fadeImageIn` および `fadeImageOut` メソッドを導入しました。これにより、正しいz-indexの重なり順を維持し、画像の入れ替え時に発生する黒い画面のちらつきを防ぎつつ、個々の画像に対してスムーズなフェード遷移を行えるようになりました。また、これらの新しいメソッドは、同じキーを使用して画像を新しいものに入れ替える際のクロスフェードにも対応しています。 (`src/core/drawer.ts`, `src/commands/ShowHandler.ts`, `src/commands/HideHandler.ts`) [[1]](diffhunk://#diff-14931e9781be534d27bb8ea2a8449587eb0009459e7c6d19353a0cfede4fc3f6R325-R382) [[2]](diffhunk://#diff-de163c10dbd2ccdbaa9109e66e89697a0d0769ef7​​5318cc17f22f6eed8c682a9L80-R94) [[3]](diffhunk://#diff-ee353e55ebb711d93095b1fe58745f099eee002cf5fa26adee864c8609b61bb1R11-L25)
- `ShowHandler` および `HideHandler` を更新し、これらの新しいフェードメソッドを使用するようにしました。これにより、他の表示要素に影響を与えることなく、対象の画像のみがフェードインまたはフェードアウトするようになります。 (`src/commands/ShowHandler.ts`, `src/commands/HideHandler.ts`) [[1]](diffhunk://#diff-de163c10dbd2ccdbaa9109e66e89697a0d0769ef7​​5318cc17f22f6eed8c682a9L80-R94) [[2]](diffhunk://#diff-ee353e55ebb711d93095b1fe58745f099eee002cf5fa26adee864c8609b61bb1R11-L25)

**画像のサイズ調整および配置機能の改善:**
- 幅や高さが指定されていない場合、アスペクト比を維持しつつ、アップスケーリング（拡大）を行わずに画面解像度内に収まるよう、キャラクター画像を自動的にリサイズするロジックを追加しました。これは「キャラクター系」のモードにのみ適用されます（背景、CG、カットイン、エフェクトなどは対象外）。(`src/commands/ShowHandler.ts`)
- 画像の配置位置の計算を調整し、指定された `pos` アンカー（top/middle/bottom）が画像の中心と正しく揃うようにしました。これにより、画像の配置における一貫性と予測可能性が向上しました。(`src/commands/ShowHandler.ts`)
- `drawCanvas` を修正し、画像の描画に指定された `size` を使用するようにしました。これにより、意図した解像度で画像がキャンバスに描画されることが保証されます。(`src/core/drawer.ts`)