### PR TITLE
Fix/npm package build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,89 @@
+name: Verify and publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '検証のみ行い、npm publishは実行しない'
+        required: false
+        default: false
+        type: boolean
+      otp:
+        description: 'npmアカウントの2要素認証コード（Automationトークン使用時は不要）'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  verify-and-publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify dist output
+        run: node scripts/verify-dist.js
+
+      - name: Check package contents (npm pack --dry-run)
+        working-directory: dist
+        run: npm pack --dry-run
+
+      - name: Check version is not already published
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Checking ${PKG_NAME}@${PKG_VERSION} on npm registry..."
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "::error::${PKG_NAME}@${PKG_VERSION} は既にnpmに公開済みです。publishする前にpackage.jsonのversionを上げてください。"
+            exit 1
+          fi
+          echo "${PKG_NAME}@${PKG_VERSION} is not published yet. OK to publish."
+
+      - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
+        working-directory: dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_OTP: ${{ inputs.otp }}
+        run: |
+          set -euo pipefail
+          if [ -n "$NPM_OTP" ]; then
+            npm publish --otp="$NPM_OTP"
+          else
+            npm publish
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### npm publish workflow結果"
+            echo ""
+            echo "- package: $(node -p "require('./dist/package.json').name")@$(node -p "require('./dist/package.json').version")"
+            echo "- dry_run: ${{ inputs.dry_run }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ jest.config.js
 task.todo
 tsconfig.json
 /src
+*.tgz

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,165 @@
+# 既知の不具合メモ
+
+cafe-story（`C:\Users\endoh\Dropbox\Development\cafe-story`）の開発中に見つかった、
+webtalekit本体の不具合をまとめる。
+
+## 1. npm公開パッケージ `webtalekit@0.3.0` が壊れている
+
+npm registry (`https://registry.npmjs.org/webtalekit`) から `webtalekit@0.3.0` を
+実際にインストールして中身を検証したところ、ビルドが通らない状態だった。
+
+検証方法:
+```bash
+mkdir tmp && cd tmp && npm init -y
+npm install webtalekit@0.3.0
+find node_modules/webtalekit -type f | sort
+```
+
+### 1-1. `src/core/domElementHandler.js` が同梱されていない
+
+`src/core/index.js` は次のようにインポートしているが、
+`domElementHandler.js`（`.ts`をコンパイルしたもの）が公開パッケージ内に存在しない。
+
+```js
+import { DomElementHandler } from './domElementHandler'
+```
+
+ローカルの開発リポジトリ（このリポジトリ）には `src/core/domElementHandler.ts` が
+存在するので、`npm run build` でのコンパイル・コピー漏れ、もしくは
+`domElementHandler.ts` 追加後にビルドし直さないままpublishした可能性が高い。
+
+この状態だと `import { Core } from 'webtalekit/src/core/'` は
+モジュール解決エラーで確実に失敗する（Node/webpackどちらでも）。
+
+再現ログ（Node ESMローダーでの検証、`./drawer`など他の相対importも拡張子なしで
+書かれているため実際にはそちらで先に落ちるが、原因は同種）:
+```
+Cannot find module '.../node_modules/webtalekit/src/core/drawer' imported from
+'.../node_modules/webtalekit/src/core/index.js'
+```
+
+### 1-2. `src/index.js`（package.jsonの`main`）自体が存在しない
+
+`package.json`:
+```json
+"main": "./src/index.js"
+```
+だが、公開パッケージに `src/index.js` が含まれていない。
+パッケージのエントリーポイントが丸ごと欠落している。
+
+### 1-3. パッケージ自身の中に `webtalekit-0.3.0.tgz` が同梱されている
+
+`node_modules/webtalekit/webtalekit-0.3.0.tgz` というファイルが公開物に含まれていた。
+`npm pack` の生成物を誤って次のpublishに含めてしまったと思われる。
+中身を展開して確認したが、同じく `domElementHandler.js` などは入っておらず、
+救済版にはなっていない。
+
+### 1-4. テストファイルが混入している
+
+`parser/checker.test.ts` が公開パッケージに含まれている。実害はないが、
+`.npmignore` または `package.json` の `files` フィールドの設定漏れと思われる。
+
+### 対応案・修正内容
+
+根本原因は3つ重なっていた:
+
+1. `tsconfig.json`の`include`に`src/core/domElementHandler.ts`と
+   `src/core/nodeToDomConverter.ts`が含まれておらず、`tsc`が
+   そもそもコンパイルしていなかった（1-1の直接原因）。→ `include`に追加。
+2. `nodeToDomConverter.ts`は`../../parser/checker`（`src/`の外）を
+   importしているため、上記2ファイルを`include`に足しただけだと
+   `tsc`が共通rootDirを`src/`ではなくプロジェクトルートと誤推論し、
+   出力が`dist/src/src/core/*.js`のように二重ネストしてしまい、
+   `domElementHandler.js`だけでなく`drawer.js`など**既存のファイルも
+   すべて**`index.js`から見て解決できない場所に出力される状態になっていた
+   （上記の`Cannot find module '.../src/core/drawer'`の再現ログと一致）。
+   → `tsconfig.json`の`outDir`を`./dist/src/`から`./dist/`に変更し、
+   ルートディレクトリの推論結果と整合させた。
+3. `package.json`の`"main": "./src/index.js"`は、ソースにもビルド後にも
+   存在しないファイルを指していた（1-2）。実際のエントリーポイントは
+   `src/core/index.js`のため`main`を修正。
+
+あわせて:
+
+- `.npmignore`に`*.tgz`を追加（1-3の再発防止）。
+- `package.json`に`"files": ["src", "parser", "engineConfig.json"]`を追加し、
+  publish時に含めるファイルをホワイトリスト化（`dist/`配下に紛れ込んだ
+  `.tgz`などの余計なファイルが誤って公開物に入らないようにした）。
+- ビルドスクリプトと`tsconfig.json`の`exclude`に`**/*.test.ts`を追加し、
+  `dist/parser/checker.test.ts`や`dist/src/commands/TriggerHandler.test.ts`
+  など、テストファイルが出力・publish対象に混入しないようにした（1-4）。
+
+修正後、`npm run build`→`dist`で`npm pack --dry-run`を実行し、
+`domElementHandler.js`等が正しい場所に出力されテストファイルが
+含まれないこと、`main`のimportチェーンがすべて解決できることを確認済み。
+`npm run test`（210 tests）もパスすることを確認した。
+
+次回publish時は`0.3.1`などにバージョンを上げ、
+`npm run build && cd dist && npm pack --dry-run`で内容を確認してから
+publishする運用にすると、今回のような欠落・混入に再度気付きやすい。
+
+---
+
+## 2. HTTP通信タグ（`<text get=".."/>` 等）の不具合
+
+`src/core/index.js` の `httpHandler` （0.2.14系・ローカル0.3.0系どちらも同一コード）。
+
+### 2-1. GET/HEAD/DELETEでも常にリクエストボディを付けてしまう
+
+```js
+const response = await fetch(line.get || line.post || line.put || line.delete, {
+  method: line.get ? 'GET' : line.post ? 'POST' : line.put ? 'PUT' : 'DELETE',
+  headers: headers,
+  body: JSON.stringify(body),
+})
+```
+
+`method`に関わらず常に`body`を付与しているため、ブラウザの仕様上ボディを持てない
+GET/HEADリクエストで `TypeError: Request with GET/HEAD method cannot have body` が
+発生する。`get`属性を使った例はすべて失敗する。
+
+**対応案**: `GET`/`HEAD`のときは`body`を渡さない（`method`が`GET`/`HEAD`のときのみ
+`fetch`のオプションから`body`キー自体を除く）。
+
+### 2-2. `<header>`/`<data>`を空タグにすると例外になる
+
+```js
+const headers = line.content
+  .filter((content) => content.type === 'header')[0]
+  .content.reduce(/* ... */)
+```
+
+`<header></header>`のように子要素が0個のタグを書くと、パーサーが
+`content: undefined`（または存在しないプロパティ）を返し、`.content.reduce(...)`が
+`TypeError: Cannot read properties of undefined (reading 'reduce')`で落ちる。
+送るヘッダー・ボディが特にない場合でも、ダミーの子要素を最低1つ入れないと
+使えない状態になっている。
+
+**対応案**: `content.content` が配列でない場合は空オブジェクトとして扱う
+（`(content.content || []).reduce(...)`など）。
+
+### 2-3. （0.2.14では未修正・ローカル0.3.0では修正済み）失敗時レスポンスの`json`未定義参照
+
+`webtalekit-alpha@0.2.14`（cafe-storyが現在使用しているバージョン）:
+```js
+} else {
+  this.sceneFile.res = json  // ← elseブロック内では`json`が未定義（ReferenceError）
+  line.error = line.content.filter((content) => content.type === 'error')[0].content
+}
+```
+`json`は`if (response.ok)`ブロック内でのみ`const`宣言されているため、
+リクエストが失敗した場合（`response.ok`が`false`）に到達する`else`ブロックで
+`ReferenceError: json is not defined`になる。
+
+ローカルの`webTaleKit`リポジトリ（0.3.0系ソース）では、`else`ブロック内でも
+`const json = await response.json()`が追加されており、**この点はすでに修正済み**。
+0.2.14系を使い続ける場合はこの修正が含まれていない点に注意。
+
+---
+
+## 動作確認環境
+
+- cafe-story: `webtalekit-alpha@0.2.14`（npm公開版、正常動作）
+- 上記npm検証: `webtalekit@0.3.0`（npm公開版、ビルド不可）
+- HTTPタグの2-1/2-2は、ローカル`webTaleKit`リポジトリの`src/core/index.js`
+  （0.3.0系ソース）でも再現するコードのまま残っている（2026年時点）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webtalekit-alpha",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webtalekit-alpha",
-      "version": "0.2.14",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "webtalekit-alpha",
-  "version": "0.2.14",
+  "name": "webtalekit",
+  "version": "0.3.0",
   "description": "Web知識でノベルゲーを作ることを目指したやつ",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,19 @@
   "name": "webtalekit",
   "version": "0.3.0",
   "description": "Web知識でノベルゲーを作ることを目指したやつ",
-  "main": "./src/index.js",
+  "main": "./src/core/index.js",
+  "files": [
+    "src",
+    "parser",
+    "engineConfig.json"
+  ],
   "scripts": {
     "lint": "eslint . --ext .ts --ext .js",
     "test": "jest",
     "setup": "npm install && cd example && npm install",
     "dev": "npm run build && cd example && npm run dev",
     "api": "node server/api.js",
-    "build": "rimraf ./dist/ && tsc && npx shx cp -r package.json README.md engineConfig.json parser/ dist/ && npx shx cp src/core/index.js  dist/src/core/",
+    "build": "rimraf ./dist/ && tsc && npx shx cp -r package.json README.md engineConfig.json parser/ dist/ && npx shx cp src/core/index.js  dist/src/core/ && npx shx rm -f dist/parser/*.test.ts dist/parser/*.test.js",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// npm publish前に dist/ の内容を検証するスクリプト。
+// - 必須ファイルの存在確認
+// - テストファイルが混入していないか確認
+// - package.jsonのmainから辿れる相対importがすべて解決できるか確認
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+
+const distDir = path.resolve(__dirname, '..', 'dist')
+let hasError = false
+
+function fail(message) {
+  hasError = true
+  console.error(`::error::${message}`)
+}
+
+console.log('## dist/ の必須ファイルを確認')
+const requiredFiles = [
+  'package.json',
+  'src/core/index.js',
+  'src/core/domElementHandler.js',
+  'src/core/nodeToDomConverter.js',
+  'src/core/drawer.js',
+  'src/core/scenarioManager.js',
+  'parser/cli.js',
+  'parser/checker.js',
+]
+for (const relPath of requiredFiles) {
+  const filePath = path.join(distDir, relPath)
+  if (!fs.existsSync(filePath)) {
+    fail(`必須ファイルが見つかりません: dist/${relPath}`)
+  }
+}
+
+console.log('## テストファイルが混入していないか確認')
+function findTestFiles(dir) {
+  const found = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      found.push(...findTestFiles(entryPath))
+    } else if (/\.test\.[jt]s$/i.test(entry.name)) {
+      found.push(entryPath)
+    }
+  }
+  return found
+}
+const testFiles = fs.existsSync(distDir) ? findTestFiles(distDir) : []
+if (testFiles.length > 0) {
+  fail(`distにテストファイルが混入しています: ${testFiles.join(', ')}`)
+}
+
+console.log('## main のimportチェーンがすべて解決できるか確認')
+const pkgPath = path.join(distDir, 'package.json')
+if (fs.existsSync(pkgPath)) {
+  const pkg = require(pkgPath)
+  const mainFile = path.resolve(distDir, pkg.main)
+  if (!fs.existsSync(mainFile)) {
+    fail(`mainファイルが見つかりません: ${mainFile}`)
+  } else {
+    const src = fs.readFileSync(mainFile, 'utf8')
+    const importLines = src.match(/^import .*/gm) || []
+    for (const line of importLines) {
+      const m = line.match(/from\s+['"](\..*?)['"]/)
+      if (!m) continue
+      const resolved = path.resolve(path.dirname(mainFile), m[1])
+      const candidates = [resolved, `${resolved}.js`, path.join(resolved, 'index.js')]
+      const found = candidates.some((candidate) => fs.existsSync(candidate))
+      if (!found) {
+        fail(`importが解決できません: "${m[1]}" (from ${path.relative(distDir, mainFile)})`)
+      }
+    }
+  }
+}
+
+if (hasError) {
+  console.error('dist/ の検証に失敗しました。')
+  process.exit(1)
+}
+console.log('dist/ の検証に成功しました。')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "outDir": "./dist/src/",
+    "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,
     "module": "commonjs",
@@ -21,6 +21,8 @@
     "src/utils/validateScenario.ts",
     "src/core/drawer.ts",
     "src/core/CommandRegistry.ts",
+    "src/core/domElementHandler.ts",
+    "src/core/nodeToDomConverter.ts",
     "src/commands/**/*.ts",
     "src/core/resourceManager.ts",
     "src/core/scenarioManager.ts",
@@ -28,5 +30,5 @@
     "src/resource/ImageObject.ts",
     "src/resource/soundObject.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
このプルリクエストでは、npmパッケージのビルドおよび公開プロセスにいくつかの重要な改善を加え、以前特定されたパッケージングの問題を修正し、公開される成果物の信頼性を向上させています。主な変更点には、パッケージのエントリポイントの修正、公開ファイルの整理、自動検証の追加、および既知の問題とその解決策に関するドキュメントの整備が含まれます。

**npmパッケージングと公開の改善:**

*   パッケージ名を `webtalekit` に変更し、`main` エントリポイントを `./src/core/index.js` に修正しました。また、必要なファイルのみが公開されるよう `"files"` ホワイトリストを追加しました。ビルドスクリプトは、出力からテストファイルを除外するようにもなりました。 (`package.json`)
*   `.npmignore` を更新して `*.tgz` ファイルを除外するようにし、パッケージの tarball ファイルが公開成果物に含まれないようにしました。

**自動検証および公開ワークフロー:**

*   検証および npm への公開を自動化する新しい GitHub Actions ワークフロー (`.github/workflows/npm-publish.yml`) を追加しました。これには、必須ファイルの確認、テストの実行、dist 出力の検証、および重複するバージョンの公開防止といったステップが含まれます。
*   `scripts/verify-dist.js` スクリプトを導入しました。このスクリプトは、必須ファイルの存在確認、テストファイルが含まれていないことの確認、および `main` エントリポイントからのすべての相対インポートが解決可能であることの検証を行います。

**ドキュメント:**

*   `docs/known-issues.md` を追加し、以前のパッケージングの問題（ファイルの欠落、誤ったエントリポイント、テストファイルや tarball ファイルの誤った混入など）を記録するとともに、その根本原因と今回のプルリクエストで適用された修正内容を説明しました。