### PR TITLE
fix: add/removeタグがCommandRegistryに未登録で実行時エラーになる不具合を修正

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,71 @@
+# 既知の不具合メモ
+
+cafe-story（`C:\Users\endoh\Dropbox\Development\cafe-story`）の開発中に見つかった、
+webtalekit本体の不具合をまとめる。
+
+## 3. `<add>`/`<remove>`タグがCommandRegistryに登録されておらず実行時エラーになる
+
+### 症状
+
+`.scene`ファイルで`<add>`/`<remove>`タグを使うと、パース自体は成功するが
+シナリオ実行時に次の例外が発生する。
+
+```
+Error: Command type "add" is not defined
+```
+
+### 原因
+
+- `parser/checker.js`には`add`/`remove`がトップレベルタグ・既知属性
+  （`add`: `target`/`name`/`class`, `remove`: `name`）として登録されており、
+  `.scene`ファイルのパースは問題なく通る。
+- DOM要素の追加・削除ロジックも`src/core/domElementHandler.ts`の
+  `addElement()`/`removeElement()`/`setVisibility()`として実装済みで、
+  `Core`のコンストラクタでインスタンス化もされている。
+- しかし、シナリオ実行時にこれらのメソッドを呼び出すコードが
+  どこにも存在しなかった。`src/commands/index.ts`の
+  `registerBuiltinCommands()`（タグ名→ハンドラの登録テーブル）に
+  `add`/`remove`のハンドラが登録されていなかったため。
+
+git blameで経緯を追うと:
+
+1. `d180d1b`「add/removeタグを追加した」時点では、当時Core直書きだった
+   `commandList`オブジェクトに`add`/`remove`ハンドラが登録されていた
+   （`add: (args) => this.domElementHandler.addElement(args)` 等）。
+2. `a6b3394`「CommandRegistry導入」で、`commandList`方式から
+   `CommandRegistry`（`src/commands/*Handler.ts`を個別クラス化して
+   `registerBuiltinCommands()`で登録する方式）へ全面リファクタされた際、
+   「既存16タグのハンドラを個別クラスとして移植」の対象リストに
+   `add`/`remove`が含まれておらず、移植から漏れた。
+
+以降、`AddHandler`/`RemoveHandler`に相当するクラスが存在しない状態が
+続いており、`domElementHandler.addElement`/`removeElement`を呼び出す
+コードは`domElementHandler.ts`自身以外どこにもなかった。テストも
+一切なかったため、CIでも検知されていなかった。
+
+### 対応済み
+
+- `src/commands/AddHandler.ts`/`RemoveHandler.ts`を新設し、既存の
+  `HideHandler`等と同じパターンで`context.core.domElementHandler.addElement`/
+  `removeElement`に委譲するようにした。
+- `src/core/CommandRegistry.ts`の`CoreFacade`に`domElementHandler`を追加し、
+  ハンドラから型安全にアクセスできるようにした。
+- `src/commands/index.ts`の`registerBuiltinCommands()`に`add`/`remove`を登録。
+- `src/core/CommandRegistry.test.ts`の登録タグ一覧テストに`add`/`remove`を追加。
+- `src/commands/AddHandler.test.ts`を追加し、`AddHandler`/`RemoveHandler`が
+  `domElementHandler`に正しく委譲することを確認。
+
+なお、`CommandRegistry.ts`が`domElementHandler.ts`をimportするようになった
+ことで、`tsc`のrootDir推論が`nodeToDomConverter.ts`経由で`parser/checker.js`
+（`src/`の外）まで巻き込み、`npm run build`の出力が`dist/src/src/...`のように
+二重ネストする不具合が本ブランチ単体でも再現したため、あわせて
+`tsconfig.json`の`outDir`変更（`./dist/src/` → `./dist/`）と
+`include`への`domElementHandler.ts`/`nodeToDomConverter.ts`追加、
+テストファイル除外（`**/*.test.ts`）も行った（npm公開パッケージのビルド
+不具合そのものについては別途調査済み。詳細は別ブランチ
+`fix/npm-package-build`を参照）。
+
+また、`jest.config.js`に`testPathIgnorePatterns: ['/node_modules/', '/dist/']`
+を追加した。`dist/`配下のビルド成果物（`checker.test.ts`等）がJestの
+テスト対象に含まれてしまっており、上記`outDir`変更と組み合わさることで
+`ts-jest`が`outDir`計算に失敗してクラッシュする状態になっていたため。

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest',
   },
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/src/commands/AddHandler.test.ts
+++ b/src/commands/AddHandler.test.ts
@@ -1,0 +1,32 @@
+import { AddHandler } from './AddHandler'
+import { RemoveHandler } from './RemoveHandler'
+import { ExecutionContext } from '../core/CommandRegistry'
+
+const createContext = (): { context: ExecutionContext; addElement: jest.Mock; removeElement: jest.Mock } => {
+  const addElement = jest.fn()
+  const removeElement = jest.fn()
+  const context = {
+    core: {
+      domElementHandler: { addElement, removeElement },
+    },
+  } as unknown as ExecutionContext
+  return { context, addElement, removeElement }
+}
+
+describe('AddHandler', () => {
+  it('domElementHandler.addElementにcommandをそのまま委譲する', async () => {
+    const { context, addElement } = createContext()
+    const command = { type: 'add', target: 'div', name: 'popup', class: 'my-popup' }
+    await new AddHandler().execute(command, context)
+    expect(addElement).toHaveBeenCalledWith(command)
+  })
+})
+
+describe('RemoveHandler', () => {
+  it('domElementHandler.removeElementにcommandをそのまま委譲する', async () => {
+    const { context, removeElement } = createContext()
+    const command = { type: 'remove', name: 'popup' }
+    await new RemoveHandler().execute(command, context)
+    expect(removeElement).toHaveBeenCalledWith(command)
+  })
+})

--- a/src/commands/AddHandler.ts
+++ b/src/commands/AddHandler.ts
@@ -1,0 +1,9 @@
+import { CommandHandler, ExecutionContext, ScenarioCommand } from '../core/CommandRegistry'
+
+export class AddHandler implements CommandHandler {
+  async execute(command: ScenarioCommand, context: ExecutionContext): Promise<void> {
+    const { core } = context
+    const line: any = command
+    core.domElementHandler.addElement(line)
+  }
+}

--- a/src/commands/RemoveHandler.ts
+++ b/src/commands/RemoveHandler.ts
@@ -1,0 +1,9 @@
+import { CommandHandler, ExecutionContext, ScenarioCommand } from '../core/CommandRegistry'
+
+export class RemoveHandler implements CommandHandler {
+  async execute(command: ScenarioCommand, context: ExecutionContext): Promise<void> {
+    const { core } = context
+    const line: any = command
+    core.domElementHandler.removeElement(line)
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,8 @@ import { SaveHandler } from './SaveHandler'
 import { LoadHandler } from './LoadHandler'
 import { TriggerHandler } from './TriggerHandler'
 import { UntriggerHandler } from './UntriggerHandler'
+import { AddHandler } from './AddHandler'
+import { RemoveHandler } from './RemoveHandler'
 
 export {
   TextHandler,
@@ -37,6 +39,8 @@ export {
   LoadHandler,
   TriggerHandler,
   UntriggerHandler,
+  AddHandler,
+  RemoveHandler,
 }
 
 /**
@@ -65,6 +69,8 @@ export function registerBuiltinCommands(registry: CommandRegistry): Record<strin
     load: new LoadHandler(),
     trigger: triggerHandler,
     untrigger: new UntriggerHandler(triggerHandler),
+    add: new AddHandler(),
+    remove: new RemoveHandler(),
   }
   registry.registerAll(handlers)
   return handlers

--- a/src/core/CommandRegistry.test.ts
+++ b/src/core/CommandRegistry.test.ts
@@ -104,13 +104,13 @@ describe('CommandRegistry', () => {
 })
 
 describe('registerBuiltinCommands', () => {
-  it('組み込み全タグ（16タグ + trigger/untrigger）を登録する', () => {
+  it('組み込み全タグ（16タグ + trigger/untrigger + add/remove）を登録する', () => {
     const registry = new CommandRegistry()
     const handlers = registerBuiltinCommands(registry)
     const expectedTags = [
       'text', 'say', 'choice', 'show', 'hide', 'newpage', 'jump', 'call',
       'moveto', 'route', 'if', 'sound', 'wait', 'dialog', 'save', 'load',
-      'trigger', 'untrigger',
+      'trigger', 'untrigger', 'add', 'remove',
     ]
     expectedTags.forEach((tag) => {
       expect(registry.has(tag)).toBe(true)

--- a/src/core/CommandRegistry.ts
+++ b/src/core/CommandRegistry.ts
@@ -1,6 +1,7 @@
 import { EventBus } from '../utils/eventBus'
 import { ScenarioManager } from './scenarioManager'
 import { Drawer } from './drawer'
+import { DomElementHandler } from './domElementHandler'
 
 /** パーサーが生成するシナリオオブジェクト1件。エンジンはこれを逐次実行する */
 export interface ScenarioCommand {
@@ -40,6 +41,7 @@ export interface CoreFacade {
   bgm: any
   store: any
   gameContainer: HTMLElement
+  domElementHandler: DomElementHandler
   isAuto: boolean
   isNext: boolean
   isSkip: boolean

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "outDir": "./dist/src/",
+    "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,
     "module": "commonjs",
@@ -21,6 +21,8 @@
     "src/utils/validateScenario.ts",
     "src/core/drawer.ts",
     "src/core/CommandRegistry.ts",
+    "src/core/domElementHandler.ts",
+    "src/core/nodeToDomConverter.ts",
     "src/commands/**/*.ts",
     "src/core/resourceManager.ts",
     "src/core/scenarioManager.ts",
@@ -28,5 +30,5 @@
     "src/resource/ImageObject.ts",
     "src/resource/soundObject.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
parser/checker.jsはadd/removeタグを既知タグとして認識し、DOM要素の 追加・削除ロジックもdomElementHandler.tsに実装済みだったが、 CommandRegistry導入時のリファクタ(a6b3394)で「既存16タグの移植」対象に add/removeが含まれておらず、ディスパッチ登録だけが漏れていた。 そのため.sceneファイルでは<add>/<remove>のパースは通るのに、実行時に `Error: Command type "add" is not defined`で落ちる状態になっていた。

- src/commands/AddHandler.ts, RemoveHandler.ts: 既存ハンドラと同じ パターンでcontext.core.domElementHandlerに委譲するハンドラを追加
- src/core/CommandRegistry.ts: CoreFacadeにdomElementHandlerを追加
- src/commands/index.ts: registerBuiltinCommands()にadd/removeを登録
- テスト: CommandRegistry.test.tsの登録タグ一覧を更新、 AddHandler/RemoveHandlerの委譲を確認するテストを追加

CommandRegistry.tsがdomElementHandler.tsをimportするようになったことで、 tscのrootDir推論がparser/checker.js(src/の外)まで巻き込まれ、 npm run buildの出力がdist/src/src/...のように二重ネストする不具合が 本ブランチ単体でも再現したため、tsconfig.jsonのoutDir/include/exclude もあわせて修正(fix/npm-package-buildで特定した根本原因と同種)。 また、dist/配下のテスト用ビルド成果物がJestのテスト対象に含まれて ts-jestがクラッシュする問題も見つかったため、jest.config.jsに testPathIgnorePatternsを追加した。

npm run test(212 tests)、npm run buildで二重ネストなしの出力を確認済み。